### PR TITLE
CI: Add Linux aarch64 target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build Python bindings
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 6 * * 1' # Run every monday at 06:00 UTC
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ['x86_64-unknown-linux-gnu', 'aarch64-unknown-linux-gnu']
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - uses: messense/maturin-action@v1
+      with:
+        maturin-version: latest
+        manylinux: auto
+        target: ${{ matrix.target }}
+        command: build
+        args: --release --no-sdist
+
+  windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: messense/maturin-action@v1
+      with:
+        maturin-version: latest
+        command: build
+        args: --release --no-sdist
+
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install aarch64-apple-darwin toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: aarch64-apple-darwin
+    - uses: messense/maturin-action@v1
+      with:
+        maturin-version: latest
+        command: build
+        args: --release --no-sdist --universal2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,16 +28,8 @@ jobs:
 
   macos:
     runs-on: macos-latest
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-      fail-fast: false
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Install aarch64-apple-darwin toolchain
       uses: actions-rs/toolchain@v1
       with:
@@ -47,4 +39,4 @@ jobs:
       with:
         maturin-version: latest
         command: publish
-        args: -i python --no-sdist --universal2 -u hledoux -p ${{ secrets.PASSWORD_PYPI }}
+        args: --no-sdist --universal2 -u hledoux -p ${{ secrets.PASSWORD_PYPI }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,12 +7,17 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ['x86_64-unknown-linux-gnu', 'aarch64-unknown-linux-gnu']
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - uses: messense/maturin-action@v1
       with:
         maturin-version: latest
         manylinux: auto
+        target: ${{ matrix.target }}
         command: publish
         args: --no-sdist -u hledoux -p ${{ secrets.PASSWORD_PYPI }}
 


### PR DESCRIPTION
This PR contains three commits:

- The first one removes the build matrix for macOS that was added to build wheels for all the Python versions.  The [messense/maturin-action](https://github.com/messense/maturin-action) was updated in release [v1.16](https://github.com/messense/maturin-action/releases/tag/v1.16.0) to recognize all Python versions installed on macOS.
- The second one builds and publishes Arm64 (aarch64) wheels on Linux by adding the `aarch64-unknown-linux-gnu` targets to the build matrix.
- The third one adds a build workflow that mirrors the publish workflow, but uses `maturin build --release` instead of `maturin publish`. The workflow is ran on every push, pull request and once a week.

Linux aarch64 wheels are nice for people using ARMv8 systems, like Raspberry Pi's and such.