### PR TITLE
Readme: Add Licence and PyPi badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![GitHub license](https://img.shields.io/github/license/cityjson/cjvalpy)](https://github.com/cityjson/cjvalpy/blob/main/LICENSE) [![PyPI version](https://badge.fury.io/py/cjvalpy.svg)](https://badge.fury.io/py/cjvalpy)
+
 # cjvalpy
 
 


### PR DESCRIPTION
Adds badges for the MIT License and PyPi wheels to the Readme.md